### PR TITLE
Update page-feature-pages.php

### DIFF
--- a/page-feature-pages.php
+++ b/page-feature-pages.php
@@ -57,7 +57,7 @@
           </p>
           <?php the_excerpt();?>
         </div><!-- end .featured-wrap -->
-      <?php endwhile;  wp_reset_query; ?>	
+      <?php endwhile;  wp_reset_query(); ?>	
         
       </div><!-- end .home-features -->		
 


### PR DESCRIPTION
Fatal error occurs because wp_reset_query is missing the parentheses to make it a function call.